### PR TITLE
Fix infinite loop in ancestor traversal

### DIFF
--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -64,10 +64,7 @@ impl FieldFormatter for NestedFmt {
 
         if let Some(span) = current_span {
             let extensions = span.extensions();
-            if let Some(record) = extensions.get::<fluent::Map>() {
-                event_record.insert(span.name().to_owned(), record.clone().into());
-            }
-            while let Some(span) = span.parent() {
+            for span in span.scope() {
                 if let Some(record) = extensions.get::<fluent::Map>() {
                     event_record.insert(span.name().to_owned(), record.clone().into());
                 }
@@ -97,14 +94,10 @@ impl FieldFormatter for FlattenFmt {
         event.record(event_record.deref_mut());
 
         if let Some(span) = current_span {
-            let extensions = span.extensions();
-            if let Some(record) = extensions.get::<fluent::Map>() {
-                event_record.update(record);
-            }
-            while let Some(span) = span.parent() {
+            for span in span.scope() {
                 let extensions = span.extensions();
                 if let Some(record) = extensions.get::<fluent::Map>() {
-                    event_record.update(record)
+                    event_record.update(record);
                 }
             }
         }


### PR DESCRIPTION
First of all, just want to say thank you for this crate! :)

Previously, this line would loop infinitely, since it was always retrieving the leaf span's parent, instead of the current span's parent:
```rust
while let Some(span) = span.parent() {
```
This PR uses [`SpanRef::scope`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/registry/struct.SpanRef.html#method.scope) to properly traverse the parents of the span being recorded.

Fixes #1 