### PR TITLE
Upgrade rmp-serde to version 1 to pick up fix for RUSTSEC-2022-0092

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-features = false
 [dependencies]
 tracing-core = "0.1"
 crossbeam-channel = "0.5"
-rmp-serde = "0.15"
+rmp-serde = "1"
 
 [dev-dependencies.tracing]
 version = "0.1"


### PR DESCRIPTION
RustSec advisory: https://rustsec.org/advisories/RUSTSEC-2022-0092.html

This is fixed in rmp-serde 1.1.1: https://github.com/3Hren/msgpack-rust/commit/5c11a5e
