### PR TITLE
Using timestamps in nanos since epoch instead of seconds

### DIFF
--- a/src/fluent.rs
+++ b/src/fluent.rs
@@ -138,7 +138,7 @@ impl fmt::Debug for Value {
 #[derive(Debug)]
 ///Representation of fluent entry within `Message`
 pub struct Record {
-    time: u64,
+    time: u128,
     entries: Map,
 }
 
@@ -147,7 +147,7 @@ impl Record {
     ///Creates record with current timestamp
     pub fn now() -> Self {
         let time = match std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH) {
-            Ok(time) => time.as_secs(),
+            Ok(time) => time.as_nanos(),
             Err(_) => panic!("SystemTime is before UNIX!?"),
         };
 


### PR DESCRIPTION
Hey, first of all thanks for this crate!  'm using it, but I would like for it to have better precision on the timestamps.
Fluentd has nanosecond support, so we can send it from here as nanos since epoch and have better granularity in logs. Optionally, we could also add a with_timer option to the Builder and have as_secs as the default if this change has consequences I don't see. Does this sound reasonable?