### PR TITLE
Nipati/kustoprop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default-features = false
 tracing-core = "0.1"
 crossbeam-channel = "0.5"
 rmp-serde = "1"
+indexmap = "1.9"
 
 [dev-dependencies.tracing]
 version = "0.1"

--- a/src/fluent.rs
+++ b/src/fluent.rs
@@ -4,18 +4,18 @@ use serde::ser::{Serialize, Serializer, SerializeTuple, SerializeMap};
 use std::time;
 use core::fmt;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 #[derive(Clone)]
 #[repr(transparent)]
-///HashMap object suitable for fluent record.
-pub struct Map(HashMap<Cow<'static, str>, Value>);
+///IndexMap object suitable for fluent record.
+pub struct Map(IndexMap<Cow<'static, str>, Value>);
 
 impl Map {
     #[inline(always)]
     ///Creates new empty map.
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(IndexMap::new())
     }
 }
 
@@ -27,7 +27,7 @@ impl core::fmt::Debug for Map {
 }
 
 impl core::ops::Deref for Map {
-    type Target = HashMap<Cow<'static, str>, Value>;
+    type Target = IndexMap<Cow<'static, str>, Value>;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!```
 
 #![warn(missing_docs)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::style))]
+// #![cfg_attr(feature = "cargo-clippy", allow(clippy::style))]
 
 use core::num;
 use std::io::Write;


### PR DESCRIPTION
Use IndexMap for deterministic ordering for properties log

    In kusto ICEEvent logs - with the use of HashMap in fluentd library, key-value
    pairs in properties json are not ordered across the rows.
    With the use of IndexMap, the ordering will be deterministic based on
    sequence of insertion on the map & independent of the hash
    function
